### PR TITLE
BlenderGDSII - Linux and Blender >v4.x compatibility

### DIFF
--- a/BlendGDSII.py
+++ b/BlendGDSII.py
@@ -19,15 +19,63 @@ import subprocess
 
 #find newest blender.exe installation
 import glob
-def blender_path_search_function(pattern):
-    return glob.glob(pattern)[-1]
-
-DEFAULT_BLENDER_PATH_PATTERN = r'C:\Program Files\Blender Foundation\Blender*\blender.exe'
-BLENDER_PATH = blender_path_search_function(DEFAULT_BLENDER_PATH_PATTERN)
+import shutil
 
 #find my path
 import os
 MY_PATH = os.path.dirname(__file__)
+
+def blender_path_search_function(pattern):
+    results = glob.glob(pattern)
+    return results[-1] if results else None
+
+def guess_blender_path():
+    #if blender is on path, this will locate it for win/lin
+    blender = shutil.which("blender")
+    if blender:
+        return blender
+
+    # If not, we must check wildcard installs.
+    if sys.platform == "win32":
+        patterns = [
+            r"C:\Program Files\Blender Foundation\Blender*\blender.exe",
+            r"C:\Program Files\Blender Foundation\Blender\*\blender.exe",
+        ]
+
+    else:  # linux/macOS system structures
+
+        patterns = [
+            "/usr/bin/blender",
+            "/usr/local/bin/blender",
+            "/opt/blender-*/blender",
+            os.path.expanduser("~/Downloads/blender-*/blender"),
+            os.path.expanduser("~/Downloads/Blender*/blender"),
+            os.path.expanduser("~/bin/blender"),
+        ]
+
+    #Then we use the patterns in glob to find installs, and pick the latest version
+    matches = []
+    for pattern in patterns:
+        match = blender_path_search_function(pattern)
+        if match:
+            matches.append(match)
+            
+    if matches:
+        matches.sort()
+        return matches[-1]  # newest version
+
+    #We must return none if nothing is found.
+    return None
+
+
+if sys.platform == 'win32':
+    DEFAULT_BLENDER_PATH_PATTERN = r'C:\Program Files\Blender Foundation\Blender\*\blender.exe'
+else:
+    DEFAULT_BLENDER_PATH_PATTERN = "/opt/blender-*/blender"
+
+BLENDER_PATH = guess_blender_path()
+
+
 
 with open(MY_PATH + '/saved/example.txt','w') as f:
     f.write(f'''{MY_PATH}\\example\\example.gds
@@ -296,8 +344,8 @@ def gdsiistl(gdsii_file_path, layerstack):
             layer_pointer += len(faces)
 
         # save layer to STL file
-        empty_file_path = '\\'.join(gdsii_file_path.replace('/','\\').split('\\')[:-1]) + '\\'
-        filename = empty_file_path.replace('.','_') + f'{layername}.stl'
+        empty_file_path = os.path.dirname(gdsii_file_path)
+        filename = os.path.join(empty_file_path, f'{layername}.stl')
         print('    ({}, {}) to {}'.format(layer, layername, filename))
         layer_mesh_object = mesh.Mesh(layer_mesh_data, remove_empty_areas=False)
         layer_mesh_object.save(filename)
@@ -311,6 +359,7 @@ class App(customtkinter.CTk):
     lb = list(range(10))
     gdsii_file_path = ''
     selected_blender_path = BLENDER_PATH
+    
 
     material_options = [
         'Gold',
@@ -360,7 +409,7 @@ class App(customtkinter.CTk):
 
         self.label_1 = customtkinter.CTkLabel(master=self.frame_left,
                                               text="BlendGDSII\nlayout to blender",
-                                              text_font=("Roboto Medium", -16))  # font name and size in px
+                                              font=("Roboto Medium", -16))  # font name and size in px
         self.label_1.grid(row=1, column=0, pady=10, padx=10)
 
         #Convert button
@@ -556,7 +605,7 @@ class App(customtkinter.CTk):
 
     def open_gds(self):
         filePath = askopenfilename(
-            initialdir='C:/', title='Select a File', filetype=(("GDSII File", ".gds"), ("All Files", "*.*")))
+            initialdir='C:/', title='Select a File', filetypes=(("GDSII File", ".gds"), ("All Files", "*.*")))
         with open(filePath, 'rb') as askedFile:
             fileContents = askedFile.read()
         self.gdsii_file_path = filePath
@@ -647,25 +696,25 @@ class App(customtkinter.CTk):
                 layer = int(entry.get())
                 layerstack[layer] = (0,100,f'gdsii_{layer}')
 
-        gdsii_file_path = self.gdsii_file_path_button.text.replace('\n','')
+        gdsii_file_path = self.gdsii_file_path_button.cget("text").replace('\n','')
 
         print(f'Building stl files...')
         print(layerstack)
         gdsiistl(gdsii_file_path,layerstack)
         
     def open_blender(self):
-        gdsii_file_path = self.gdsii_file_path_button.text.replace('\n','')
-        stl_folder = '\\'.join(gdsii_file_path.replace('/','\\').split('\\')[:-1])
+        gdsii_file_path = self.gdsii_file_path_button.cget("text").replace('\n','')
+        stl_folder = os.path.dirname(gdsii_file_path)
         print(stl_folder)
 
         cmd = [
             self.selected_blender_path,
             '--factory-startup',
             '-P',
-            MY_PATH + r'\bpy_import_stls.py',
+            os.path.join(MY_PATH, 'bpy_import_stls.py'),
             '--',
             stl_folder,
-            MY_PATH + r'\materials.blend',
+            os.path.join(MY_PATH, 'materials.blend'),
             ','.join([str(check.get()) for check,_,_,_,_ in self.lb][::-1]),
             ','.join([entry.get() for _,entry,_,_,_ in self.lb][::-1]),
             ','.join([material.get() for _,_,material,_,_ in self.lb][::-1]),
@@ -684,26 +733,29 @@ class App(customtkinter.CTk):
     def change_blender_path(self, event=None):
         self.blender_path_win = customtkinter.CTkToplevel()
         self.blender_path_win.wm_title("Change the Blender path")
-
         line1 = 'Adapt the blender path here'
         line2 = 'You may use the * symbol for any arbitrary piece in the path.'
-        line3 = 'For instance use this to select the last version of Blender:' 
-        
+        line3 = 'For instance use this to select the last version of Blender:'
+    
+        if sys.platform == 'win32':
+            example_path = r'C:\Program Files\Blender Foundation\Blender\*\blender.exe'
+        else:
+            example_path = '/opt/blender-*/blender'
+    
         self.label_blender_path_descr = customtkinter.CTkLabel(master=self.blender_path_win,
                                               text=f"{line1}\n{line2}\n{line3}",
-                                              text_font=("Roboto Medium", -14))  # font name and size in px
+                                              font=("Roboto Medium", -14))
         self.label_blender_path_descr.grid(row=0, column=0, pady=10, padx=10)
-        
+    
         self.label_blender_path = customtkinter.CTkLabel(master=self.blender_path_win,
-                                              text=r'e.g.: "C:\Program Files\Blender Foundation\Blender*\blender.exe"',
-                                              text_font=("Roboto Medium", -12))  # font name and size in px
+                                              text=f'e.g.: "{example_path}"',
+                                              font=("Roboto Medium", -12))
         self.label_blender_path.grid(row=1, column=0, pady=10, padx=10)
-        
+    
         self.blender_path_entry = customtkinter.CTkEntry(master=self.blender_path_win,
-            placeholder_text=r'C:\Program Files\Blender Foundation\Blender*\blender.exe',
+            placeholder_text=example_path,
             width=500)
         self.blender_path_entry.grid(row=2, column=0, pady=0, padx=0, sticky="n")
-
         b = customtkinter.CTkButton(self.blender_path_win, text="Check", command=self.check_blender_path)
         b.grid(row=3, column=0)
         b = customtkinter.CTkButton(self.blender_path_win, text="Save", command=self.save_blender_path)
@@ -712,23 +764,23 @@ class App(customtkinter.CTk):
     def check_blender_path(self):
         try:
             checking_blender_path_pattern = self.blender_path_entry.get()
-            if not checking_blender_path_pattern.endswith('blender.exe'):
+            if checking_blender_path_pattern == "":
+                checking_blender_path_pattern = self.selected_blender_path
+            if sys.platform == 'win32' and not checking_blender_path_pattern.endswith('blender.exe'):
                 self.label_blender_path.configure(text='Please include the "blender.exe" at the end of the path.')
             else:
                 checking_blender_path = blender_path_search_function(checking_blender_path_pattern)
-                
                 self.label_blender_path.configure(text=f'Your new Blender path would be:\n{checking_blender_path}\nPlease save to confirm.')
         except:
             self.label_blender_path.configure(text='This path is not valid...')
-        
+
     def save_blender_path(self):
         try:
             selected_blender_path_pattern = self.blender_path_entry.get()
-            if not selected_blender_path_pattern.endswith('blender.exe'):
+            if sys.platform == 'win32' and not selected_blender_path_pattern.endswith('blender.exe'):
                 self.label_blender_path.configure(text='Please include the "blender.exe" at the end of the path.')
             else:
                 self.selected_blender_path = blender_path_search_function(selected_blender_path_pattern)
-
                 print(f'Blender path changed to:\n{self.selected_blender_path}')
                 self.blender_path_win.destroy()
         except:

--- a/BlendGDSII.py
+++ b/BlendGDSII.py
@@ -8,7 +8,7 @@ import customtkinter
 
 #gdsiistl
 import sys # read command-line arguments
-import gdspy # open gds file
+import gdspy # open gds file - Note, requires workload "Desktop development with C++" from MSVC Build Tools from https://visualstudio.microsoft.com/visual-cpp-build-tools/ to be built. 
 import numpy as np # fast math on lots of points
 from stl import mesh # write stl file (python package name is "numpy-stl")
 import triangle # triangulate polygons
@@ -767,6 +767,7 @@ class App(customtkinter.CTk):
             if checking_blender_path_pattern == "":
                 checking_blender_path_pattern = self.selected_blender_path
             if sys.platform == 'win32' and not checking_blender_path_pattern.endswith('blender.exe'):
+                
                 self.label_blender_path.configure(text='Please include the "blender.exe" at the end of the path.')
             else:
                 checking_blender_path = blender_path_search_function(checking_blender_path_pattern)
@@ -777,7 +778,10 @@ class App(customtkinter.CTk):
     def save_blender_path(self):
         try:
             selected_blender_path_pattern = self.blender_path_entry.get()
+            if selected_blender_path_pattern == "":
+                selected_blender_path_pattern = self.selected_blender_path
             if sys.platform == 'win32' and not selected_blender_path_pattern.endswith('blender.exe'):
+                print(selected_blender_path_pattern)
                 self.label_blender_path.configure(text='Please include the "blender.exe" at the end of the path.')
             else:
                 self.selected_blender_path = blender_path_search_function(selected_blender_path_pattern)

--- a/bpy_import_stls.py
+++ b/bpy_import_stls.py
@@ -33,7 +33,7 @@ layer_stack = argv[3]
 material_stack = argv[4]
 dimension_stack = argv[5]
 
-glob_search = stl_folder_path + r'\*.stl'
+glob_search = os.path.join(stl_folder_path, '*.stl')
 print(f'Looking for stl files:\n{glob_search}')
 stl_files = glob.glob(glob_search)
 print(f'found: {stl_files}')
@@ -73,6 +73,19 @@ bpy.data.objects['Cube'].select_set(True)
 bpy.data.objects['Light'].select_set(True)
 bpy.ops.object.delete(use_global=False)
 
+def import_stl(filepath):
+    # Blender 4.x+
+    if hasattr(bpy.ops.wm, "stl_import"):
+        obj = bpy.ops.wm.stl_import(filepath=filepath)
+
+    # Blender ≤ 3.x
+    elif hasattr(bpy.ops.import_mesh, "stl"):
+        obj = bpy.ops.import_mesh.stl(filepath=filepath)
+    
+    else:
+        raise RuntimeError("No STL importer found in this Blender version")
+    return(obj)
+
 for stl_check,stl_layer,stl_material,stl_dimension in zip(stl_checks,stl_layers,stl_materials,stl_dimensions):
     if stl_check:
         #find file
@@ -82,8 +95,8 @@ for stl_check,stl_layer,stl_material,stl_dimension in zip(stl_checks,stl_layers,
         
         if filename != '':
             print(f'Blender - Importing {filename}')
-            obj = bpy.ops.import_mesh.stl(filepath=filename)
-            obj_name = filename.replace('/','\\').split('\\')[-1][:-4]
+            obj = import_stl(filename)
+            obj_name = os.path.splitext(os.path.basename(filename))[0]
             mat_name = obj_name + '_material'
 
             bpy.data.objects[obj_name].select_set(True)
@@ -146,9 +159,10 @@ for area in bpy.context.screen.areas:
 
         bpy.data.objects['Camera'].data.clip_start = clip_start_value
         bpy.data.objects['Camera'].data.clip_end = clip_end_value
-
-        bpy.ops.view3d.view_selected(ctx)            # points view
-        bpy.ops.view3d.camera_to_view_selected(ctx)   # points camera
+        
+        with bpy.context.temp_override(area=area, region=area.regions[-1]): # FIX
+            bpy.ops.view3d.view_selected() # points view
+            bpy.ops.view3d.camera_to_view_selected() # points camera 
 
 bpy.ops.object.light_add(type='SUN', align='WORLD', location=(0, 0, 0), rotation=(0.261799, 0.261799*2, 0), scale=(1, 1, 1))
 bpy.data.objects["Sun"].select_set(True)
@@ -156,9 +170,31 @@ ob = bpy.context.active_object
 ob.data.energy = 5000
 bpy.data.objects["Sun"].select_set(False)
 
-bpy.context.scene.eevee.use_ssr = True
-bpy.context.scene.eevee.use_ssr_refraction = True
-bpy.context.scene.render.film_transparent = True
 
+scene = bpy.context.scene
+eevee = scene.eevee
+
+# Check for Blender ≤3.x to enable old EEVEE features
+if hasattr(eevee, "use_ssr"):
+    eevee.use_ssr = True
+
+    if hasattr(eevee, "use_ssr_refraction"):
+        eevee.use_ssr_refraction = True
+
+# And if not, check for EEVEE next, so Blender ≥4.x
+else:
+    if hasattr(eevee, "use_raytracing"):
+        eevee.use_raytracing = True
+
+    # Closest behaviour to SSR
+    if hasattr(eevee, "ray_tracing_method"):
+        eevee.ray_tracing_method = 'SCREEN'
+
+
+# Set Transparent background as default for convenience - although, this may confuse non-blender users?
+render = scene.render
+
+if hasattr(render, "film_transparent"):
+    render.film_transparent = True
 
 bpy.ops.object.select_all(action='DESELECT')


### PR DESCRIPTION
I have used this software a lot in the past, and figured I'd give back to the community when I discovered breaking changes. 
Recently, changes to the python api in blender made the "open in blender" function not work for versions >4.x. This was not a problem for me initially, as the stl files would still be saved and could be imported seperately. However, I recently migrated to linux - and realised that the software does not work because of how paths were handled. 

This pull request aims to change a few main things:
- Make path identification agnostic (replacing string manipulation of "\\" with os.path,join/os.path.expanduser/os.path.dirname) so that windows/macOS/Linux paths all work as intended without any complaints.
- Update stl import calls and eevee settings changes to support blender versions > 4.x (while preserving vesrions 3.x compatibility, hopefully)
- Update blender path finding logic to find more possibilities of install locations (including allowing you to check and save without entering anything into the text field)

I have tested the tool (launching the BlendGDSII.py from the spyder IDE) on both Linux (openSUSE) and Windows 11 with blender version 5.1 and in both cases the tool created the STL files, imported them into blender and correctly assigned materials. I have not compiled an executable.

Total specific file changes can be found here:

BlendGDSII.py changes:
Removed the use of "//" for directory handling, and replaced all with os.path,join/os.path.expanduser/os.path.dirname to make it os agnostic.

Added support for non .exe executable binaries, allowing linux to use the python script normally

The logic for finding the directory was updated to account for linux/macos locations as well. The selected blender version will always be the latest unless specified otherwise. The original glob search was maintained.

bpy_import_stls.py changes:
Removed the use of "//" for directory handling, and replaced all with os.path.join to make it os agnostic.

Preserved ops calls through the blender 3.x api calls, but also added support for eevee next, including migrating away from the legacy stl to the built-in bpy.ops.wm.import_stl() function instead.

Breaking changes:
Updated syntax for latest version of customtkinter== 5.2.2. This means that dependencies will likely need to be updated